### PR TITLE
Stop using global import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 const App: React.FC = () => {
 	return <></>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './index.css';


### PR DESCRIPTION
# What
- Stop using global import (e.g. `import * as React from 'react'`)